### PR TITLE
Fix profile picture injection for standard certificate id cards

### DIFF
--- a/app/helpers/routes.js
+++ b/app/helpers/routes.js
@@ -42,11 +42,31 @@ function split(thing) {
   }
 }
 
-function listEndpoints(app, filter = '') {
-  app._router.stack.forEach(print.bind(null, []))
+const handleSort = (a, b) => {
+  if (`${a.method}${a.path}` < `${b.method}${b.path}`) {
+    return -1
+  }
+  if (`${a.method}${a.path}` == `${b.method}${b.path}`) {
+    return 0
+  }
+
+  return `${a.method}${a.path}` > `${b.method}${b.path}`
+}
+
+async function listEndpoints(app, filter = '') {
+  await app._router.stack.forEach(print.bind(null, []))
+
+  let current = routes[0].method || ''
   routes
-    .filter((r) => !filter || r.path.includes(filter))
-    .forEach((r) => console.log(r))
+    .filter((r) => !filter || r.path.includes(filter)) // Matches routes that include the filter (i.e.: 'certificates')
+    .sort(handleSort)
+    .forEach((r) => {
+      if (current !== r.method) {
+        console.log()
+        current = r.method
+      }
+      console.log(r)
+    })
 }
 
 module.exports = { listEndpoints }

--- a/app/middleware/id-card-middleware.js
+++ b/app/middleware/id-card-middleware.js
@@ -2,7 +2,7 @@ const fs = require('node:fs')
 const PDFDocument = require('pdfkit')
 const bwipjs = require('bwip-js')
 
-const { documentNumber, urlToBuffer } = require('../helpers/converters')
+const { documentNumber } = require('../helpers/converters')
 const { OPITO_HUB_URL } = require('../helpers/constants')
 
 const cardWidth = 242
@@ -73,11 +73,7 @@ const generateStandardIdCard = (req, profilePicture) =>
 
         doc.text(certificate, { width: cardWidth, height: cardHeight })
 
-        const buffer = await urlToBuffer(profilePicture)
-
-        fs.writeFileSync('./test.jpg', buffer, 'binary')
-
-        doc.image('./test.jpg', 2, 94, { width: 76 })
+        doc.image(profilePicture, 2, 94, { width: 76 })
 
         doc.addPage()
 


### PR DESCRIPTION
## Details
During the generation of standard id cards an bug was detected. `UNABLE_TO_VERIFY_LEAF_SIGNATURE`.
The reason was a wrong implementation of the profile picture injection into the id card pdf document.
